### PR TITLE
enable-swap-only-when-tokens-and-inputs-are-truish

### DIFF
--- a/src/components/v2/RightSection/RightSection.tsx
+++ b/src/components/v2/RightSection/RightSection.tsx
@@ -359,7 +359,7 @@ export const RightSection = () => {
         )}
         {accountWhiteList && (
           <PrimaryButton
-            disabled={trade ? false : true}
+            disabled={isASelected && isBSelected && typedValue ? false : true}
             mrgn="0px 0px 12px 0px"
             onClick={() => {
               updateSwapParams({ start: true })


### PR DESCRIPTION
- instead of trade, utilize isASelected, isBSelected and typedValue as conditions for swap qualification 